### PR TITLE
Fix version conflicts caused by PR#34

### DIFF
--- a/src/CrawlerProventos.Infrastructure/CrawlerProventos.Infrastructure.csproj
+++ b/src/CrawlerProventos.Infrastructure/CrawlerProventos.Infrastructure.csproj
@@ -6,13 +6,13 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql.Design" Version="1.1.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Pomelo.EntityFrameworkCore.MySql from 3.1.1 to 5.0.1. [(PR#34)](https://github.com/juniosilvac/CrawlerProventos/pull/34).
Hope this fix can help you.

Best regards,
sucrose